### PR TITLE
Fix mkdocs nav reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,7 +142,7 @@ nav:
         - fsdl-2022/labs/fsdl-2022-lab-0-overview.md
         - fsdl-2022/labs/fsdl-2022-lab-1-3-pre-requisites.md
       - Misc:
-        - fsdl-2021/2023-02-22-References.md
+        - fsdl-2022/2023-02-22-References.md
     - A_Karpathy's Lectures:
       - karpathy/micrograd-1.md
       - karpathy/makemore-1.md


### PR DESCRIPTION
## Summary
- fix reference to references page in mkdocs nav

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870f99c51f48322bbee6c2f4dbb6787