### PR TITLE
Fix typo in notes

### DIFF
--- a/docs/dlio_nlp/2023-02-13-Coursera-NLP-w1.md
+++ b/docs/dlio_nlp/2023-02-13-Coursera-NLP-w1.md
@@ -13,7 +13,7 @@ tags: [Coursera, NLP_Tensorflow]
 
 ## Preparing and encoding text for training in a neural network
 
-Encoding letters in a word in ASCII - semantics not covneyed
+Encoding letters in a word in ASCII - semantics not conveyed
 e.g. of LISTEN vs SILENT
 
 Encode words/Tokenize


### PR DESCRIPTION
## Summary
- fix a misspelling in the NLP course notes

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb5ec8fc83228a8cf64714b20f7a